### PR TITLE
Create Response class

### DIFF
--- a/sample/HomeController.php
+++ b/sample/HomeController.php
@@ -18,22 +18,20 @@
 		 * @throws JsonException
 		 */
 		public function home(Request $request) : void {
-			//$request->send([ "message" => "Hello from controller::home" ]); // Old way of doing it
-
-			$request
+			// Old way of doing it
+			/*$request
 				->header("Access-Control-Allow-Origin", "https://demo.local")
 				->header("Content-Type", "application/json")
 				->status(401, 'Not Authorized')
-				->send([]);
+				->send([ "message" => "Hello from controller::home" ]);*/
 
 			// New way of doing it
 			Response::
 			withHeader("Access-Control-Allow-Origin", "https://demo.local")::
 			withHeader("Content-Type", "application/json")::
 			withStatus(401, 'Not authorized')::
-			//withBody([])::
-			send([]);
-			//send();
+			withBody([ "message" => "Hello from controller::home" ])::
+			send();
 		}
 
 		public function getUsers(Request $request) : void {

--- a/sample/HomeController.php
+++ b/sample/HomeController.php
@@ -3,6 +3,8 @@
 	namespace Gac\Routing\sample;
 
 	use Gac\Routing\Request;
+	use Gac\Routing\Response;
+	use JsonException;
 
 	class HomeController
 	{
@@ -12,8 +14,26 @@
 			echo "Hello from controller";
 		}
 
+		/**
+		 * @throws JsonException
+		 */
 		public function home(Request $request) : void {
-			$request->send([ "message" => "Hello from controller::home" ]);
+			//$request->send([ "message" => "Hello from controller::home" ]); // Old way of doing it
+
+			$request
+				->header("Access-Control-Allow-Origin", "https://demo.local")
+				->header("Content-Type", "application/json")
+				->status(401, 'Not Authorized')
+				->send([]);
+
+			// New way of doing it
+			Response::
+			withHeader("Access-Control-Allow-Origin", "https://demo.local")::
+			withHeader("Content-Type", "application/json")::
+			withStatus(401, 'Not authorized')::
+			//withBody([])::
+			send([]);
+			//send();
 		}
 
 		public function getUsers(Request $request) : void {

--- a/sample/index.php
+++ b/sample/index.php
@@ -73,6 +73,8 @@
 				->send([ 'message' => 'Welcome' ]);
 		});
 
+		$routes->add("/home/test", [ HomeController::class, "home" ]);
+
 		$routes
 			->prefix('/user')
 			->middleware([ 'verify_token' ])

--- a/src/Request.php
+++ b/src/Request.php
@@ -91,6 +91,9 @@
 		 * @param string $message Message to be sent int the header alongside the status code
 		 *
 		 * @return Request Returns an instance of the Request class so that it can be chained on
+		 * @deprecated Soon this option will be removed and should be replaced with a call to the Response class
+		 * New way of using the Response class: Response::withStatus(401, 'Not Authorized');
+		 *
 		 */
 		public function status(int $statusCode = 200, string $message = '') : self {
 			header("HTTP/1.1 $statusCode $message");
@@ -99,6 +102,9 @@
 
 		/**
 		 * Method used for setting custom header properties
+		 *
+		 * @deprecated Soon this option will be removed and should be replaced with a call to the Response class
+		 * New way of using the Response class: Response::withHeader('header-key', 'header-value');
 		 *
 		 * @param string|array|object $key Header key value
 		 * @param mixed $value Header value
@@ -120,6 +126,9 @@
 
 		/**
 		 * Send response back
+		 *
+		 * @deprecated Soon this option will be removed and should be replaced with a call to the Response class
+		 * New way of using the Response class: Response::status(200, 'OK')::setBody($output);
 		 *
 		 * @param string|array|object $output Value to be outputted as part of the response
 		 * @param array|object|null $headers Optional list of custom header properties to be sent with the response

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,0 +1,177 @@
+<?php
+	declare( strict_types=1 );
+
+	namespace Gac\Routing;
+
+	use JsonException;
+
+	class Response
+	{
+		/**
+		 * @var int HTTP status code to be sent in the response header
+		 */
+		private static int $statusCode = 200;
+
+		/**
+		 * @var string  HTTP status message to be sent in the response header
+		 */
+		private static string $statusMessage = "OK";
+
+		/**
+		 * @var string HTTP version to be sent in the response header
+		 */
+		private static string $httpVersion = "HTTP/1.1";
+
+		/**
+		 * @var mixed|string HTTP response body content
+		 */
+		private static mixed $body = "";
+
+		/**
+		 * @var Response|null Instance of the Response class
+		 */
+		private static ?Response $instance = NULL;
+
+		/**
+		 * Use to send the output back to the client
+		 *
+		 * @param string $type Type of response to be returned (ex JSON)
+		 *
+		 * @throws JsonException If the response type == JSON and json_encode fails to encode the body data
+		 *
+		 * @return Response Returns an instance of itself to allow method chaining
+		 */
+		public static function send(array|object|string $data = NULL, string $type = "JSON") : self {
+			if ( !is_null($data) ) {
+				self::$body = $data;
+			}
+
+			echo match ( mb_strtoupper($type) ) {
+				"JSON" => self::json(),
+			};
+
+			return self::$instance;
+		}
+
+		/**
+		 * Private method for turning response body into json encoded string
+		 *
+		 * @throws JsonException If the response type == JSON and json_encode fails to encode the body data
+		 *
+		 * @return string|bool Returns a JSON encoded string on success or FALSE on failure
+		 */
+		public static function json() : string|bool {
+			return json_encode(self::$body, JSON_THROW_ON_ERROR);
+		}
+
+		/**
+		 * Method used to set the response body data that will be returned with send method
+		 *
+		 * @param array|object|string $data Body data to be set
+		 *
+		 * @return Response Returns an instance of itself to allow method chaining
+		 */
+		public static function withBody(array|object|string $data) : self {
+			self::$body = $data;
+			return self::$instance;
+		}
+
+		/**
+		 * Private method used to set the HTTP status on the response header
+		 *
+		 * @param bool $replace Indicated if the similar existing header value should be replaced on second one appended
+		 *
+		 * @return void
+		 */
+		private static function setHTTPStatus(bool $replace = false) : void {
+			header(self::$httpVersion . ' ' . self::$statusCode . ' ' . self::$statusMessage, $replace,
+				self::$statusCode);
+		}
+
+		/**
+		 * Method used to set the HTTP status code and message in the response header
+		 *
+		 * @param int $code HTTP status code to be sent back
+		 * @param string $message HTTP status message to be sent back
+		 *
+		 * @return Response Returns an instance of itself to allow method chaining
+		 */
+		public static function withStatus(int $code, string $message) : self {
+			self::$statusCode = $code;
+			self::$statusMessage = $message;
+			self::setHTTPStatus();
+			return self::$instance;
+		}
+
+		/**
+		 * Method used for setting a key-value pair in the response header
+		 *
+		 * @param string|array|object $key Header key
+		 * @param mixed $value Header value
+		 *
+		 * @return Response Returns an instance of itself to allow method chaining
+		 */
+		public static function withHeader(string|array|object $key, mixed $value) : self {
+			if ( is_string($key) ) {
+				header("$key: $value");
+			} elseif ( is_array($key) || is_object($key) ) {
+				$keys = $key;
+				foreach ( $keys as $key => $value ) {
+					header("$key: $value");
+				}
+			}
+
+			return self::$instance;
+		}
+
+		/**
+		 * Method used for retrieving an instance of the Response class
+		 *
+		 * @return Response Returns an existing instance of itself or creates a new one
+		 */
+		public static function getInstance() : Response {
+			if ( is_null(self::$instance) ) {
+				self::$instance = new Response();
+			}
+
+			return self::$instance;
+		}
+
+		/**
+		 * Method used for setting HTTP status code in the response header
+		 *
+		 * @param int $statusCode HTTP status code
+		 *
+		 * @return Response Returns an instance of itself to allow method chaining
+		 */
+		public static function setStatusCode(int $statusCode) : self {
+			self::$statusCode = $statusCode;
+			self::setHTTPStatus(true);
+			return self::$instance;
+		}
+
+		/**
+		 * Method used for setting HTTP status message in the resposne header
+		 *
+		 * @param string $statusMessage HTTP status message
+		 *
+		 * @return Response Returns an instance of itself to allow method chaining
+		 */
+		public static function setStatusMessage(string $statusMessage) : self {
+			self::$statusMessage = $statusMessage;
+			self::setHTTPStatus(true);
+			return self::$instance;
+		}
+
+		/**
+		 * Method used for setting HTTP version in the response header
+		 *
+		 * @param string $httpVersion HTTP version (ex HTTP/1.0 or HTTP/1.1)
+		 *
+		 * @return Response Returns an instance of itself to allow method chaining
+		 */
+		public static function setHttpVersion(string $httpVersion) : self {
+			self::$httpVersion = $httpVersion;
+			return self::$instance;
+		}
+	}

--- a/src/Response.php
+++ b/src/Response.php
@@ -50,7 +50,7 @@
 				"JSON" => self::json(),
 			};
 
-			return self::$instance;
+			return self::getInstance();
 		}
 
 		/**
@@ -73,7 +73,7 @@
 		 */
 		public static function withBody(array|object|string $data) : self {
 			self::$body = $data;
-			return self::$instance;
+			return self::getInstance();
 		}
 
 		/**
@@ -100,7 +100,7 @@
 			self::$statusCode = $code;
 			self::$statusMessage = $message;
 			self::setHTTPStatus();
-			return self::$instance;
+			return self::getInstance();
 		}
 
 		/**
@@ -121,7 +121,7 @@
 				}
 			}
 
-			return self::$instance;
+			return self::getInstance();
 		}
 
 		/**
@@ -131,7 +131,7 @@
 		 */
 		public static function getInstance() : Response {
 			if ( is_null(self::$instance) ) {
-				self::$instance = new Response();
+				self::$instance = new static();
 			}
 
 			return self::$instance;
@@ -147,7 +147,7 @@
 		public static function setStatusCode(int $statusCode) : self {
 			self::$statusCode = $statusCode;
 			self::setHTTPStatus(true);
-			return self::$instance;
+			return self::getInstance();
 		}
 
 		/**
@@ -160,7 +160,7 @@
 		public static function setStatusMessage(string $statusMessage) : self {
 			self::$statusMessage = $statusMessage;
 			self::setHTTPStatus(true);
-			return self::$instance;
+			return self::getInstance();
 		}
 
 		/**
@@ -172,6 +172,33 @@
 		 */
 		public static function setHttpVersion(string $httpVersion) : self {
 			self::$httpVersion = $httpVersion;
-			return self::$instance;
+			return self::getInstance();
+		}
+
+		/**
+		 * Method used for retrieving response body data
+		 *
+		 * @return mixed Returns body data to be or that was already sent back
+		 */
+		public static function getBody() : mixed {
+			return self::$body;
+		}
+
+		/**
+		 * Method used for retrieving HTTP status code for the response
+		 *
+		 * @return int Returns HTTP status code
+		 */
+		public static function getStatusCode() : int {
+			return self::$statusCode;
+		}
+
+		/**
+		 * Method used for retrieving HTTP status message for the response
+		 *
+		 * @return string Returns HTTP status message
+		 */
+		public static function getStatusMessage() : string {
+			return self::$statusMessage;
 		}
 	}

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,0 +1,66 @@
+<?php
+
+
+	use Gac\Routing\Response;
+
+	it("can get an instance of a response class", function () {
+		$response = Response::getInstance();
+		expect($response)->toBeInstanceOf(Response::class);
+	});
+
+	it("can set response body data", function () {
+		$response = Response::getInstance();
+		$data = [ "message" => "OK" ];
+		$response::withBody($data);
+
+		expect($response::getBody())->toEqual($data);
+	});
+
+	it("can convert array into json", function () {
+		$response = Response::getInstance();
+		$array = [ "message" => "Hello World" ];
+		$converted = json_encode($array);
+
+		$result = $response::withBody($array)::json();
+
+		expect($result)
+			->toBeJson()
+			->and($result)
+			->toEqual($converted);
+	});
+
+	it("can set HTTP status code", function () {
+		$response = Response::getInstance();
+		try {
+			$response::setStatusCode(401);
+		} catch ( Exception ) {
+			//silently ignore because of headers already sent error
+		} finally {
+			expect($response::getStatusCode())->toEqual(401);
+		}
+	});
+
+	it("can set HTTP status message", function () {
+		$response = Response::getInstance();
+		try {
+			$response::setStatusMessage('Not Authorized');
+		} catch ( Exception ) {
+			//silently ignore because of headers already sent error
+		} finally {
+			expect($response::getStatusMessage())->toEqual('Not Authorized');
+		}
+	});
+
+	it("can set both HTTP status message and code", function () {
+		$response = Response::getInstance();
+		try {
+			$response::withStatus(404, 'Not Found');
+		} catch ( Exception ) {
+			//silently ignore because of headers already sent error
+		} finally {
+			expect($response::getStatusCode())
+				->toEqual(404)
+				->and($response::getStatusMessage())
+				->toEqual("Not Found");
+		}
+	});


### PR DESCRIPTION
This pr will add a new class called `Response` which should be used to separate logic from `Request` class so that each handles their own respective values.

This also means that in the `Request` class following methods will get deprecated in following versions, but for now will only get a deprecation warning:

* [status](https://github.com/gigili/PHP-routing/blob/f76d4782636b86e6d99b0a829530df9b90a3552b/src/Request.php#L95)
* [header](https://github.com/gigili/PHP-routing/blob/f76d4782636b86e6d99b0a829530df9b90a3552b/src/Request.php#L109)
* [send](https://github.com/gigili/PHP-routing/blob/f76d4782636b86e6d99b0a829530df9b90a3552b/src/Request.php#L127)

Once these methods have officially been removed from the `Request` class, it will allow for renaming of existing method `headers` into just `header` 